### PR TITLE
Fix pub/sub use in example

### DIFF
--- a/examples/pubsub.php
+++ b/examples/pubsub.php
@@ -7,7 +7,7 @@ $loop = React\EventLoop\Factory::create();
 $context = new React\ZMQ\Context($loop);
 
 $sub = $context->getSocket(ZMQ::SOCKET_SUB);
-$sub->bind('tcp://127.0.0.1:5555');
+$sub->connect('tcp://127.0.0.1:5555');
 $sub->subscribe('foo');
 
 $sub->on('message', function ($msg) {
@@ -15,7 +15,7 @@ $sub->on('message', function ($msg) {
 });
 
 $pub = $context->getSocket(ZMQ::SOCKET_PUB);
-$pub->connect('tcp://127.0.0.1:5555');
+$pub->bind('tcp://127.0.0.1:5555');
 
 $i = 0;
 $loop->addPeriodicTimer(1, function () use (&$i, $pub) {


### PR DESCRIPTION
Reading this http://api.zeromq.org/2-1:zmq-bind It seems that it should be that way.
