### PR TITLE
Fixed .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ php:
 before_script:
   - pear channel-discover pear.zero.mq
   - pecl install pear.zero.mq/zmq-beta
-  - curl -s http://getcomposer.org/installer | php
-  - php composer.phar install
+  - composer install --dev
 
 script: phpunit --coverage-text


### PR DESCRIPTION
Changed two parts of .travis.yml (builds will pass again)
- After "pecl install" one does not need to add the "extension"-statement to php.ini manually
- Composer is preinstalled on the travis workers
