### PR TITLE
Improve docblock for Zmq\Context

### DIFF
--- a/src/Context.php
+++ b/src/Context.php
@@ -10,7 +10,8 @@ use ZMQSocket;
 /**
  * @mixin ZMQContext
  *
- * @method SocketWrapper getSocket
+ * @method SocketWrapper getSocket($type, $persistent_id = null, $on_new_socket = null)
+ * @see \ZmqContext::getSocket()
  */
 class Context
 {


### PR DESCRIPTION
In phpStorm (and likely other IDEs) a warning was given for calling `$context->getSocket(ZMQ::SOCKET_PULL)` (or any other socket value) as no parameters were specified in the docblock. This PR simply alters the docblock to add the available parameters and a reference to the method call which is wrapped by this object.
