### PR TITLE
Set the socket and buffer in SocketWrapper to null on close

### DIFF
--- a/src/SocketWrapper.php
+++ b/src/SocketWrapper.php
@@ -25,7 +25,7 @@ class SocketWrapper extends EventEmitter
     /**
      * @var ZMQSocket|null
      */
-    protected $socket;
+    protected $socket = null;
 
     /**
      * @var LoopInterface
@@ -35,7 +35,7 @@ class SocketWrapper extends EventEmitter
     /**
      * @var Buffer|null
      */
-    protected $buffer;
+    protected $buffer = null;
 
     /**
      * @param ZMQSocket     $socket
@@ -139,8 +139,8 @@ class SocketWrapper extends EventEmitter
         $this->loop->removeStream($this->fileDescriptor);
         $this->buffer->removeAllListeners();
         $this->removeAllListeners();
-        unset($this->buffer);
-        unset($this->socket);
+        $this->buffer = null;
+        $this->socket = null;
         $this->closed = true;
     }
 


### PR DESCRIPTION
This is to prevent
```php
PHP Notice:  Undefined property: React\ZMQ\SocketWrapper::$socket in /var/www/html/movim/vendor/react/zmq/src/SocketWrapper.php on line 63
```
and an infinite loop in `SocketWrapper->handleEvent()`